### PR TITLE
Improved plist parser

### DIFF
--- a/mobsf/StaticAnalyzer/models.py
+++ b/mobsf/StaticAnalyzer/models.py
@@ -83,6 +83,7 @@ class StaticAnalyzerIOS(models.Model):
     BINARY_INFO = models.TextField(default={})
     PERMISSIONS = models.TextField(default={})
     ATS_ANALYSIS = models.TextField(default=[])
+    TRANSPORT_SECURITY_INFO = models.TextField(default={})
     BINARY_ANALYSIS = models.TextField(default=[])
     MACHO_ANALYSIS = models.TextField(default={})
     IOS_API = models.TextField(default={})
@@ -98,6 +99,7 @@ class StaticAnalyzerIOS(models.Model):
     APPSTORE_DETAILS = models.TextField(default={})
     SECRETS = models.TextField(default=[])
     TRACKERS = models.TextField(default={})
+    AD_NETWORK_IDENTIFIERS = models.TextField(default={})
 
 
 class StaticAnalyzerWindows(models.Model):

--- a/mobsf/StaticAnalyzer/views/ios/adnetworkidentifiers.py
+++ b/mobsf/StaticAnalyzer/views/ios/adnetworkidentifiers.py
@@ -1,0 +1,90 @@
+known_adnetworks = {
+    '4fzdc2evr5': 'Aarki',
+    '23zd986j2c': 'adgoji',
+    'ydx93a7ass': 'Adikteev',
+    'v72qych5uu': 'Appier',
+    '6xzpu9s2p8': 'Applift',
+    'mlmmfzh3r3': 'Appreciate',
+    'c6k4g5qg8m': 'Beeswax',
+    'hs6bdukanm': 'Criteo',
+    'm8dbw4sv7c': 'Dataseat',
+    'w9q455wk68': 'Hybrid',
+    'yclnxrl5pm': 'Jampp',
+    '4468km3ulz': 'Kayzen',
+    't38b2kh725': 'Lifestreet',
+    '7ug5zh24hu': 'Liftoff',
+    '9t245vhmpl': 'Moloco',
+    'cad8qz2s3j': 'MYAPPFREE',
+    '44jx6755aq': 'Persona.ly',
+    'tl55sbb4fm': 'PubNative',
+    '2u9pt9hc89': 'Remerge',
+    '5a6flpkh64': 'RevX',
+    '8s468mfl3y': 'RTBHouse',
+    'klf5c3l5u5': 'Sift',
+    'av6w8kgt66': 'ScaleMonk',
+    'ppxm28t8ap': 'Smadex',
+    '44n7hlldy6': 'SpykeMedia',
+    '6964rsfnh4': 'ThingOrTwo',
+    '3rd42ekr43': 'YouAppi',
+    '4pfyvq9l8r': 'AdColony',
+    '488r3q3dtq': 'Adtiming',
+    'ludvb6z3bs': 'AppLovin',
+    'lr83yxwka7': 'Apptimus',
+    'wg4vff78zm': 'Bidmachine',
+    '3sh42y64q3': 'Centro',
+    'f38h382jlk': 'Chartboost',
+    '9rd848q2bz': 'Criteo',
+    'prcb7njmu6': 'CrossInstall',
+    '52fl2v3hgk': 'Curate',
+    'm5mvw97r93': 'DisciplineDigital',
+    'v9wttpbfk9': 'Facebook Audience Network 1',
+    'n38lu8286q': 'Facebook Audience Network 2',
+    'fz2k2k5tej': 'FeedMob',
+    'g2y4y55b64': 'GlobalWide',
+    'cstr6suwn9': 'AdMob',
+    'wzmmz9fp6w': 'InMobi',
+    'su67r6k2v3': 'ironSource',
+    'v79kvwwj4g': 'Kidoz',
+    '5lm9lj6jb7': 'Loopme',
+    'zmvfpc5aq8': 'Maiden',
+    'kbd757ywx3': 'Mintegral',
+    '275upjj5gd': 'Mobupps',
+    '238da6jt44': 'Pangle China',
+    '22mmun2rn5': 'Pangle Non China',
+    '24zw6aqk47': 'Qverse',
+    'glqzh8vgby': 'Sabio Mobile',
+    '424m5254lk': 'Snap Inc.',
+    'f73kdq92p3': 'Spotad',
+    'ecpz2srf59': 'TapJoy',
+    'pwa73g5rt2': 'Tremor',
+    '4dzt52r2t5': 'Unity',
+    'bvpn9ufa9b': 'Unity',
+    'gta9lk7p23': 'Vungle',
+}
+
+
+def check_adnetworkidentifiers(p_list):
+    """Collect all available AdNetworkItems."""
+    adnetworkidentifiers = []
+
+    skadnetworkitems = p_list.get('SKAdNetworkItems', [])
+    if not skadnetworkitems:
+        return []
+
+    if isinstance(skadnetworkitems, dict):
+        skadnetworkitems = [skadnetworkitems]
+
+    for dic_item in skadnetworkitems:
+        adnetworkidentifier = dic_item.get('SKAdNetworkIdentifier')
+        if adnetworkidentifier is None:
+            continue
+
+        adnetworkidentifier = adnetworkidentifier.split('.')[0]
+
+        known_adnetworkidentifier = known_adnetworks.get(adnetworkidentifier)
+        if known_adnetworkidentifier is not None:
+            dic_item['known_adnetworkidentifier'] = known_adnetworkidentifier
+
+        adnetworkidentifiers.append(dic_item)
+
+    return adnetworkidentifiers

--- a/mobsf/StaticAnalyzer/views/ios/db_interaction.py
+++ b/mobsf/StaticAnalyzer/views/ios/db_interaction.py
@@ -38,6 +38,8 @@ def get_context_from_db_entry(db_entry):
             'binary_info': python_dict(db_entry[0].BINARY_INFO),
             'permissions': python_dict(db_entry[0].PERMISSIONS),
             'ats_analysis': python_list(db_entry[0].ATS_ANALYSIS),
+            'transport_security_info':
+                python_list(db_entry[0].TRANSPORT_SECURITY_INFO),
             'binary_analysis': python_list(db_entry[0].BINARY_ANALYSIS),
             'macho_analysis': python_dict(db_entry[0].MACHO_ANALYSIS),
             'ios_api': python_dict(db_entry[0].IOS_API),
@@ -53,6 +55,8 @@ def get_context_from_db_entry(db_entry):
             'appstore_details': python_dict(db_entry[0].APPSTORE_DETAILS),
             'secrets': python_list(db_entry[0].SECRETS),
             'trackers': python_dict(db_entry[0].TRACKERS),
+            'adnetworkidentifiers':
+                python_dict(db_entry[0].AD_NETWORK_IDENTIFIERS),
 
         }
         return context
@@ -91,6 +95,8 @@ def get_context_from_analysis(app_dict,
             'binary_info': bin_dict['bin_info'],
             'permissions': info_dict['permissions'],
             'ats_analysis': info_dict['inseccon'],
+            'transport_security_info':
+                info_dict['transport_security_info'],
             'binary_analysis': bin_dict['bin_code_analysis'],
             'macho_analysis': bin_dict['checksec'],
             'ios_api': code_dict['api'],
@@ -106,6 +112,7 @@ def get_context_from_analysis(app_dict,
             'appstore_details': app_dict['appstore'],
             'secrets': app_dict['secrets'],
             'trackers': code_dict['trackers'],
+            'adnetworkidentifiers': info_dict['adnetworkidentifiers'],
         }
         return context
     except Exception:
@@ -142,6 +149,8 @@ def save_or_update(update_type,
             'BINARY_INFO': bin_dict['bin_info'],
             'PERMISSIONS': info_dict['permissions'],
             'ATS_ANALYSIS': info_dict['inseccon'],
+            'TRANSPORT_SECURITY_INFO':
+                info_dict['transport_security_info'],
             'BINARY_ANALYSIS': bin_dict['bin_code_analysis'],
             'MACHO_ANALYSIS': bin_dict['checksec'],
             'IOS_API': code_dict['api'],
@@ -157,6 +166,7 @@ def save_or_update(update_type,
             'APPSTORE_DETAILS': app_dict['appstore'],
             'SECRETS': app_dict['secrets'],
             'TRACKERS': code_dict['trackers'],
+            'AD_NETWORK_IDENTIFIERS': info_dict['adnetworkidentifiers'],
         }
         if update_type == 'save':
             db_entry = StaticAnalyzerIOS.objects.filter(

--- a/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
@@ -22,6 +22,9 @@ from mobsf.StaticAnalyzer.views.ios.permission_analysis import (
 from mobsf.StaticAnalyzer.views.ios.app_transport_security import (
     check_transport_security,
 )
+from mobsf.StaticAnalyzer.views.ios.adnetworkidentifiers import (
+    check_adnetworkidentifiers,
+)
 from mobsf.StaticAnalyzer.views.common.shared_func import (
     is_secret,
 )
@@ -55,11 +58,13 @@ def plist_analysis(src, is_source):
             'plist_xml': '',
             'permissions': {},
             'inseccon': [],
+            'transport_security_info': {},
             'bundle_name': '',
             'build_version_name': '',
             'bundle_url_types': [],
             'bundle_supported_platforms': [],
             'bundle_version_name': '',
+            'adnetworkidentifiers': [],
         }
         plist_file = None
         plist_files = []
@@ -117,6 +122,8 @@ def plist_analysis(src, is_source):
         plist_info['bundle_url_types'] = btype
         plist_info['bundle_supported_platforms'] = plist_obj.get(
             'CFBundleSupportedPlatforms', [])
+        plist_info['adnetworkidentifiers'] = \
+            check_adnetworkidentifiers(plist_obj)
         logger.info('Checking Permissions')
         logger.info('Checking for Insecure Connections')
         for plist_file_ in plist_files:
@@ -126,7 +133,11 @@ def plist_analysis(src, is_source):
             # Check for app-permissions
             plist_info['permissions'].update(check_permissions(plist_obj_))
             # Check for ats misconfigurations
-            plist_info['inseccon'] += check_transport_security(plist_obj_)
+            ats_inseccon, ats_transport_security_info = \
+                check_transport_security(plist_obj_)
+            plist_info['inseccon'] += ats_inseccon
+            plist_info['transport_security_info'] = \
+                ats_transport_security_info
         return plist_info
     except Exception:
         logger.exception('Reading from Info.plist')


### PR DESCRIPTION
This PR implements two major improvements in plist parser:

parser for SKAdNetworkItems introduced in iOS 11.3 (https://developer.apple.com/documentation/bundleresources/information_property_list/skadnetworkitems) including list of known ad network identifiers
machine-readable ATS structure. Currently mobSF provides only result of analysis of ATS but not raw ATS structure which is useful for further processing
